### PR TITLE
ci: fix naming for branch protections

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,20 +6,20 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    name: Lint
     steps:
       - name: Download actionlint
         run: |
           mkdir -p "$HOME/bin"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$HOME/bin"
           echo "${HOME}/bin" >> "$GITHUB_PATH"
-      - name: Lint
-        uses: open-turo/actions-node/lint@v3
+      - uses: open-turo/actions-node/lint@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
+    name: Test
     steps:
-      - name: Test
-        uses: open-turo/actions-node/test@v3
+      - uses: open-turo/actions-node/test@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Steps were named, not Jobs.