### PR TITLE
feat: add support for @semantic-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ of the plugins to work correctly.
   protection rules (see [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule))
 - `NPM_TOKEN`. A NPM token so the package can be published to NPM (a `.npmrc` file with extra configuration can also be used)
 
+### @semantic-release/exec
+
+This preset includes @semantic-release/exec to run custom scripts. It supports scripts for the `publish`, `success`
+and `fail` hooks.
+
+The convention is that the configuration will run the script if there is an executable file
+like `./script/semantic-release-<hook>`.
+
+These scripts must follow the convention of the [@semantic-release/exec](https://github.com/semantic-release/exec#configuration)
+plugin (e.g. in the publish hook, the release information can be written to stdout as parseable JSON, but nothing else).
+
+If there is no file, then this plugin will be a noop.
+
+Scripts don't receive any argument.
+
 ## Development
 
 Install [pre-commit](https://pre-commit.com/) and the commit hooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
+        "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^8.0.7",
         "@semantic-release/npm": "^9.0.1",
@@ -2105,6 +2106,25 @@
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+      "dependencies": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@semantic-release/git": {
@@ -15821,6 +15841,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
       "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
+    },
+    "@semantic-release/exec": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-6.0.3.tgz",
+      "integrity": "sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==",
+      "requires": {
+        "@semantic-release/error": "^3.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^5.0.0",
+        "lodash": "^4.17.4",
+        "parse-json": "^5.0.0"
+      }
     },
     "@semantic-release/git": {
       "version": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Turo semantic-release configuration",
   "dependencies": {
     "@semantic-release/commit-analyzer": "^9.0.2",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.7",
     "@semantic-release/npm": "^9.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,5 +58,16 @@ export = {
     ],
     "@semantic-release/github",
     "semantic-release-fotingo",
+    [
+      "@semantic-release/exec",
+      {
+        failCmd:
+          "[ -x ./script/semantic-release-fail ] && ./script/semantic-release-fail '${nextRelease.version}' || true",
+        publishCmd:
+          "[ -x ./script/semantic-release-publish ] && ./script/semantic-release-publish '${nextRelease.version}' || true",
+        successCmd:
+          "[ -x ./script/semantic-release-success ] && ./script/semantic-release-success '${nextRelease.version}' || true",
+      },
+    ],
   ],
-};
+} as const;

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,13 +1,33 @@
 import config from "./";
 
+// We have a set of plugins that ideally should run after every other plugin to guarantee that things like publishing to NPM
+// already happen before these plugins run
+const pluginsThatGoAtTheEnd = new Set([
+  "@semantic-release/exec",
+  "semantic-release-fotingo",
+]);
+
+/**
+ * Given a semantic release plugin config, return the plugin name
+ * @param p Plugin config
+ * @returns Plugin name
+ */
+const getPluginName = (p: typeof config.plugins[number]) => {
+  if (typeof p === "string") {
+    return p;
+  }
+  return p[0];
+};
+
 /**
  * Semantic release configuration for NPM projects. It extends the default configuration by publishing to NPM
  * and creating a Pull Request with version updates in files like package.json
  */
 export = {
-  ...config,
   plugins: [
-    ...config.plugins,
+    ...config.plugins.filter(
+      (p) => !pluginsThatGoAtTheEnd.has(getPluginName(p))
+    ),
     [
       "@semantic-release/npm",
       {
@@ -22,5 +42,8 @@ export = {
           "ci(release): ${nextRelease.version} <% nextRelease.channel !== 'next' ? print('[skip ci]') : print('') %>\n\n${nextRelease.notes}",
       },
     ],
+    ...config.plugins.filter((p) =>
+      pluginsThatGoAtTheEnd.has(getPluginName(p))
+    ),
   ],
 };

--- a/test/npm.test.ts
+++ b/test/npm.test.ts
@@ -24,4 +24,13 @@ describe("npm", () => {
       ).toMatchSnapshot();
     }
   );
+
+  test("@semantic-release/exec and semantic-release-fotingo aree the last plugins", () => {
+    expect(npm.plugins[npm.plugins.length - 2]).toBe(
+      "semantic-release-fotingo"
+    );
+    expect(npm.plugins[npm.plugins.length - 1][0]).toBe(
+      "@semantic-release/exec"
+    );
+  });
 });


### PR DESCRIPTION

**Description**

This PR adds support to optionally use the `@semantic-release/exec` plugin as part of this preset.

If files for the semantic release hooks are present then they will be run. If not, it will be a noop.

Supported hooks are: `fail`, `publish` and `success`.

The convention is that the files live in `./script/semantic-release-<hook>` and that they are executable.

**Changes**

* fix(deps): add @semantic-release/exec
* feat: add support for @semantic-release/exec

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
