### PR TITLE
fix: update glob to match any open api spec yaml file

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -4,7 +4,7 @@ import {
   SemanticReleasePlugin,
 } from "~/_config";
 
-const openApiSpecGlob = "spec/**/openapi.yaml";
+const openApiSpecGlob = "spec/*.yaml";
 
 const semanticReleaseOpenApi = (
   apiSpecFiles: string[]


### PR DESCRIPTION
The current glob that is used to create semantic-release preset for openapi is restrictive and looks for a specific file named openapi.yaml under any directory in the path /spec. The fix is to relax this and allow any yaml file under the path /spec.