### PR TITLE
fix: update glob to match any open api spec yaml file

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -4,7 +4,7 @@ import {
   SemanticReleasePlugin,
 } from "~/_config";
 
-const openApiSpecGlob = "spec/*.yaml";
+const openApiSpecGlob = "spec/**/*.yaml";
 
 const semanticReleaseOpenApi = (
   apiSpecFiles: string[]

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -4,7 +4,7 @@ import {
   SemanticReleasePlugin,
 } from "~/_config";
 
-const openApiSpecGlob = "spec/**/openapi.yaml";
+const openApiSpecGlob = "spec/*.yaml";
 
 const semanticReleaseOpenApi = (
   apiSpecFiles: string[]

--- a/test/__snapshots__/openapi.test.ts.snap
+++ b/test/__snapshots__/openapi.test.ts.snap
@@ -7,7 +7,7 @@ exports[`openapi adds gradle-semantic-release-plugin, semantic-release/git, and 
   "@aensley/semantic-release-openapi",
   {
     "apiSpecFiles": [
-      "spec/**/openapi.yaml",
+      "spec/**/*.yaml",
     ],
   },
 ]
@@ -20,7 +20,7 @@ exports[`openapi adds gradle-semantic-release-plugin, semantic-release/git, and 
     "assets": [
       "gradle.properties",
       "README.md",
-      "spec/**/openapi.yaml",
+      "spec/**/*.yaml",
     ],
     "message": "ci(release): \${nextRelease.version} <% nextRelease.channel !== 'next' ? print('[skip ci]') : print('') %>
 


### PR DESCRIPTION
The current glob that is used to create semantic-release preset for openapi is restrictive and looks for a specific file named openapi.yaml under any directory in the path /spec. The fix is to relax this and allow any yaml file under the path /spec.