### PR TITLE
Revert "fix(deps): update dependency @semantic-release/github to v9"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,3 @@ jobs:
       - uses: open-turo/actions-node/test@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-  release-notes:
-    runs-on: ubuntu-latest
-    name: Release notes preview
-    env:
-      NPM_TOKEN: ${{ secrets.OPEN_TURO_NPM_TOKEN }}
-    steps:
-      - uses: open-turo/actions-release/release-notes-preview@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@semantic-release/github": "^9.0.0",
+        "@semantic-release/github": "^8.0.7",
         "@semantic-release/npm": "^10.0.0",
         "@semantic-release/release-notes-generator": "^10.0.3",
         "conventional-changelog-conventionalcommits": "^5.0.0",
@@ -79,107 +79,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@octokit/openapi-types": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-      "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@octokit/plugin-retry": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
-      "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@octokit/plugin-throttling": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
-      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": "^4.0.0"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@octokit/types": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.2.0"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@semantic-release/github": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
-      "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
-      "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^6.1.2",
-        "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/plugin-throttling": "^5.2.3",
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "globby": "^11.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
-        "mime": "^3.0.0",
-        "p-filter": "^2.0.0",
-        "url-join": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@semantic-release/github/node_modules/fs-extra": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@aensley/semantic-release-openapi/node_modules/@semantic-release/npm": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
@@ -217,17 +116,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@aensley/semantic-release-openapi/node_modules/brace-expansion": {
@@ -322,18 +210,6 @@
       "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/https-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@aensley/semantic-release-openapi/node_modules/minimatch": {
@@ -2724,25 +2600,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-      "dependencies": {
-        "p-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@aensley/semantic-release-openapi/node_modules/semantic-release": {
       "version": "19.0.5",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
@@ -2853,11 +2710,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/@aensley/semantic-release-openapi/node_modules/yargs": {
       "version": "16.2.0",
@@ -4822,33 +4674,20 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
-      "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-Czz/59VefU+kKDy+ZfDwtOIYIkFjExOKf+HA92aiTZJ6EfWpFzYQWw0l54ji8bVmyhc+mGaLUbSUmXazG7z5OQ==",
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
         "@octokit/request": "^6.0.0",
         "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^8.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-    },
-    "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.2.0"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -4919,62 +4758,6 @@
         "@octokit/core": ">=3"
       }
     },
-    "node_modules/@octokit/plugin-retry": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.0.tgz",
-      "integrity": "sha512-mfON7q30NLdivuJktZuSP6I4/WPMjc/bcoxcHEWXd4esedHTqQpp3OUq2NzD2+M+J6o33zYDtJTl4qtRYh8HQQ==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-    },
-    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.2.0"
-      }
-    },
-    "node_modules/@octokit/plugin-throttling": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
-      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "^4.0.0"
-      }
-    },
-    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/openapi-types": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-    },
-    "node_modules/@octokit/plugin-throttling/node_modules/@octokit/types": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.2.0"
-      }
-    },
     "node_modules/@octokit/request": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
@@ -5017,11 +4800,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
     "node_modules/@octokit/types": {
       "version": "8.0.0",
@@ -5231,163 +5009,45 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.2.tgz",
-      "integrity": "sha512-FDwR9Tkz14MR/HF6srbHDuqLPUI0GmPgn4tkjfPi45/1oZedqEXC3TqSHK3+ykJmWj1sXgs94zwGI10VR5o6kg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.7.tgz",
+      "integrity": "sha512-VtgicRIKGvmTHwm//iqTh/5NGQwsncOMR5vQK9pMT92Aem7dv37JFKKRuulUsAnUOIlO4G8wH3gPiBAA0iW0ww==",
       "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^7.0.0",
-        "@octokit/plugin-retry": "^5.0.0",
-        "@octokit/plugin-throttling": "^6.0.0",
+        "@octokit/rest": "^19.0.0",
         "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^4.0.1",
-        "debug": "^4.3.4",
-        "dir-glob": "^3.0.1",
-        "globby": "^13.1.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^11.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.4",
         "mime": "^3.0.0",
-        "p-filter": "^3.0.0",
-        "url-join": "^5.0.0"
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14.17"
       },
       "peerDependencies": {
-        "semantic-release": ">=20.1.0"
+        "semantic-release": ">=18.0.0-beta.1"
       }
     },
-    "node_modules/@semantic-release/github/node_modules/@octokit/openapi-types": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
-      "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
+    "node_modules/@semantic-release/github/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@octokit/types": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.2.0"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=14.14"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -5657,6 +5317,14 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -5823,6 +5491,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -9756,26 +9429,16 @@
       "optional": true
     },
     "node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -15118,17 +14781,14 @@
       }
     },
     "node_modules/p-filter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-3.0.0.tgz",
-      "integrity": "sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
       "dependencies": {
-        "p-map": "^5.1.0"
+        "p-map": "^2.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/p-is-promise": {
@@ -15170,74 +14830,29 @@
       }
     },
     "node_modules/p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "dependencies": {
-        "aggregate-error": "^4.0.0"
-      },
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map/node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map/node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map/node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/p-reduce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
       "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -16293,6 +15908,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -16519,122 +16142,6 @@
         "semantic-release": ">= 19"
       }
     },
-    "node_modules/semantic-release/node_modules/@octokit/openapi-types": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-    },
-    "node_modules/semantic-release/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-      "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@octokit/plugin-retry": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
-      "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@octokit/plugin-throttling": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
-      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "@octokit/core": "^4.0.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@octokit/types": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-      "dependencies": {
-        "@octokit/openapi-types": "^17.2.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/github": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
-      "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
-      "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^6.1.2",
-        "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/plugin-throttling": "^5.2.3",
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "globby": "^11.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
-        "mime": "^3.0.0",
-        "p-filter": "^2.0.0",
-        "url-join": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/github/node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/github/node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/github/node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/semantic-release/node_modules/@semantic-release/npm": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
@@ -16825,17 +16332,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/semantic-release/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/semantic-release/node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -16958,18 +16454,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/https-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/semantic-release/node_modules/human-signals": {
@@ -19429,17 +18913,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/semantic-release/node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-      "dependencies": {
-        "p-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/semantic-release/node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -19466,14 +18939,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/semantic-release/node_modules/p-reduce": {
@@ -19611,11 +19076,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/semantic-release/node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/semantic-release/node_modules/yocto-queue": {
       "version": "1.0.0",
@@ -20877,12 +20337,9 @@
       }
     },
     "node_modules/url-join": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -21233,82 +20690,6 @@
         "semantic-release": "^19.0.5"
       },
       "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-        },
-        "@octokit/plugin-paginate-rest": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-          "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-          "requires": {
-            "@octokit/tsconfig": "^1.0.2",
-            "@octokit/types": "^9.2.3"
-          }
-        },
-        "@octokit/plugin-retry": {
-          "version": "4.1.6",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
-          "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
-          "requires": {
-            "@octokit/types": "^9.0.0",
-            "bottleneck": "^2.15.3"
-          }
-        },
-        "@octokit/plugin-throttling": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
-          "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
-          "requires": {
-            "@octokit/types": "^9.0.0",
-            "bottleneck": "^2.15.3"
-          }
-        },
-        "@octokit/types": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-          "requires": {
-            "@octokit/openapi-types": "^17.2.0"
-          }
-        },
-        "@semantic-release/github": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
-          "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
-          "requires": {
-            "@octokit/core": "^4.2.1",
-            "@octokit/plugin-paginate-rest": "^6.1.2",
-            "@octokit/plugin-retry": "^4.1.3",
-            "@octokit/plugin-throttling": "^5.2.3",
-            "@semantic-release/error": "^3.0.0",
-            "aggregate-error": "^3.0.0",
-            "debug": "^4.0.0",
-            "dir-glob": "^3.0.0",
-            "fs-extra": "^11.0.0",
-            "globby": "^11.0.0",
-            "http-proxy-agent": "^7.0.0",
-            "https-proxy-agent": "^7.0.0",
-            "issue-parser": "^6.0.0",
-            "lodash": "^4.17.4",
-            "mime": "^3.0.0",
-            "p-filter": "^2.0.0",
-            "url-join": "^4.0.0"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "11.1.1",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-              "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-              "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            }
-          }
-        },
         "@semantic-release/npm": {
           "version": "9.0.2",
           "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
@@ -21339,14 +20720,6 @@
                 "universalify": "^2.0.0"
               }
             }
-          }
-        },
-        "agent-base": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-          "requires": {
-            "debug": "^4.3.4"
           }
         },
         "brace-expansion": {
@@ -21418,15 +20791,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
           "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g=="
-        },
-        "https-proxy-agent": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-          "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "4"
-          }
         },
         "minimatch": {
           "version": "5.1.6",
@@ -23024,19 +22388,6 @@
           "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
           "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA=="
         },
-        "p-filter": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-          "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-          "requires": {
-            "p-map": "^2.0.0"
-          }
-        },
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
-        },
         "semantic-release": {
           "version": "19.0.5",
           "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
@@ -23116,11 +22467,6 @@
           "requires": {
             "crypto-random-string": "^2.0.0"
           }
-        },
-        "url-join": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-          "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
         },
         "yargs": {
           "version": "16.2.0",
@@ -24638,32 +23984,17 @@
       }
     },
     "@octokit/core": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
-      "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-Czz/59VefU+kKDy+ZfDwtOIYIkFjExOKf+HA92aiTZJ6EfWpFzYQWw0l54ji8bVmyhc+mGaLUbSUmXazG7z5OQ==",
       "requires": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
         "@octokit/request": "^6.0.0",
         "@octokit/request-error": "^3.0.0",
-        "@octokit/types": "^9.0.0",
+        "@octokit/types": "^8.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-        },
-        "@octokit/types": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-          "requires": {
-            "@octokit/openapi-types": "^17.2.0"
-          }
-        }
       }
     },
     "@octokit/endpoint": {
@@ -24714,54 +24045,6 @@
         "deprecation": "^2.3.1"
       }
     },
-    "@octokit/plugin-retry": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.0.tgz",
-      "integrity": "sha512-mfON7q30NLdivuJktZuSP6I4/WPMjc/bcoxcHEWXd4esedHTqQpp3OUq2NzD2+M+J6o33zYDtJTl4qtRYh8HQQ==",
-      "requires": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-        },
-        "@octokit/types": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-          "requires": {
-            "@octokit/openapi-types": "^17.2.0"
-          }
-        }
-      }
-    },
-    "@octokit/plugin-throttling": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
-      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
-      "requires": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-        },
-        "@octokit/types": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-          "requires": {
-            "@octokit/openapi-types": "^17.2.0"
-          }
-        }
-      }
-    },
     "@octokit/request": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.2.tgz",
@@ -24795,11 +24078,6 @@
         "@octokit/plugin-request-log": "^1.0.4",
         "@octokit/plugin-rest-endpoint-methods": "^6.7.0"
       }
-    },
-    "@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
     "@octokit/types": {
       "version": "8.0.0",
@@ -24942,110 +24220,37 @@
       }
     },
     "@semantic-release/github": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.2.tgz",
-      "integrity": "sha512-FDwR9Tkz14MR/HF6srbHDuqLPUI0GmPgn4tkjfPi45/1oZedqEXC3TqSHK3+ykJmWj1sXgs94zwGI10VR5o6kg==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.7.tgz",
+      "integrity": "sha512-VtgicRIKGvmTHwm//iqTh/5NGQwsncOMR5vQK9pMT92Aem7dv37JFKKRuulUsAnUOIlO4G8wH3gPiBAA0iW0ww==",
       "requires": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^7.0.0",
-        "@octokit/plugin-retry": "^5.0.0",
-        "@octokit/plugin-throttling": "^6.0.0",
+        "@octokit/rest": "^19.0.0",
         "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^4.0.1",
-        "debug": "^4.3.4",
-        "dir-glob": "^3.0.1",
-        "globby": "^13.1.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
+        "aggregate-error": "^3.0.0",
+        "bottleneck": "^2.18.1",
+        "debug": "^4.0.0",
+        "dir-glob": "^3.0.0",
+        "fs-extra": "^11.0.0",
+        "globby": "^11.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
         "issue-parser": "^6.0.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.4",
         "mime": "^3.0.0",
-        "p-filter": "^3.0.0",
-        "url-join": "^5.0.0"
+        "p-filter": "^2.0.0",
+        "p-retry": "^4.0.0",
+        "url-join": "^4.0.0"
       },
       "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-        },
-        "@octokit/plugin-paginate-rest": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
-          "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
           "requires": {
-            "@octokit/tsconfig": "^1.0.2",
-            "@octokit/types": "^9.2.3"
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
           }
-        },
-        "@octokit/types": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-          "requires": {
-            "@octokit/openapi-types": "^17.2.0"
-          }
-        },
-        "agent-base": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-          "requires": {
-            "debug": "^4.3.4"
-          }
-        },
-        "aggregate-error": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-          "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-          "requires": {
-            "clean-stack": "^4.0.0",
-            "indent-string": "^5.0.0"
-          }
-        },
-        "clean-stack": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-          "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-          "requires": {
-            "escape-string-regexp": "5.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        },
-        "globby": {
-          "version": "13.1.4",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-          "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
-          "requires": {
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.2.11",
-            "ignore": "^5.2.0",
-            "merge2": "^1.4.1",
-            "slash": "^4.0.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-          "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "4"
-          }
-        },
-        "indent-string": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-        },
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
         }
       }
     },
@@ -25222,6 +24427,11 @@
         "@sinonjs/commons": "^2.0.0"
       }
     },
+    "@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -25388,6 +24598,11 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -28161,22 +27376,13 @@
       "optional": true
     },
     "http-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "requires": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-          "requires": {
-            "debug": "^4.3.4"
-          }
-        }
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
       }
     },
     "https-proxy-agent": {
@@ -31906,11 +31112,11 @@
       "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="
     },
     "p-filter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-3.0.0.tgz",
-      "integrity": "sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
       "requires": {
-        "p-map": "^5.1.0"
+        "p-map": "^2.0.0"
       }
     },
     "p-is-promise": {
@@ -31937,46 +31143,23 @@
       }
     },
     "p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "requires": {
-        "aggregate-error": "^4.0.0"
-      },
-      "dependencies": {
-        "aggregate-error": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-          "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-          "requires": {
-            "clean-stack": "^4.0.0",
-            "indent-string": "^5.0.0"
-          }
-        },
-        "clean-stack": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-          "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-          "requires": {
-            "escape-string-regexp": "5.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        },
-        "indent-string": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
-        }
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-reduce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
       "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
+    },
+    "p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "requires": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      }
     },
     "p-try": {
       "version": "2.2.0",
@@ -32728,6 +31911,11 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -32885,91 +32073,6 @@
         "yargs": "^17.5.1"
       },
       "dependencies": {
-        "@octokit/openapi-types": {
-          "version": "17.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
-          "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ=="
-        },
-        "@octokit/plugin-paginate-rest": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-          "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
-          "requires": {
-            "@octokit/tsconfig": "^1.0.2",
-            "@octokit/types": "^9.2.3"
-          }
-        },
-        "@octokit/plugin-retry": {
-          "version": "4.1.6",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
-          "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
-          "requires": {
-            "@octokit/types": "^9.0.0",
-            "bottleneck": "^2.15.3"
-          }
-        },
-        "@octokit/plugin-throttling": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
-          "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
-          "requires": {
-            "@octokit/types": "^9.0.0",
-            "bottleneck": "^2.15.3"
-          }
-        },
-        "@octokit/types": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
-          "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
-          "requires": {
-            "@octokit/openapi-types": "^17.2.0"
-          }
-        },
-        "@semantic-release/github": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
-          "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
-          "requires": {
-            "@octokit/core": "^4.2.1",
-            "@octokit/plugin-paginate-rest": "^6.1.2",
-            "@octokit/plugin-retry": "^4.1.3",
-            "@octokit/plugin-throttling": "^5.2.3",
-            "@semantic-release/error": "^3.0.0",
-            "aggregate-error": "^3.0.0",
-            "debug": "^4.0.0",
-            "dir-glob": "^3.0.0",
-            "fs-extra": "^11.0.0",
-            "globby": "^11.0.0",
-            "http-proxy-agent": "^7.0.0",
-            "https-proxy-agent": "^7.0.0",
-            "issue-parser": "^6.0.0",
-            "lodash": "^4.17.4",
-            "mime": "^3.0.0",
-            "p-filter": "^2.0.0",
-            "url-join": "^4.0.0"
-          },
-          "dependencies": {
-            "aggregate-error": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-              "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-              "requires": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-              }
-            },
-            "clean-stack": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-              "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
-            },
-            "indent-string": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-              "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-            }
-          }
-        },
         "@semantic-release/npm": {
           "version": "9.0.2",
           "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.2.tgz",
@@ -33107,14 +32210,6 @@
             }
           }
         },
-        "agent-base": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-          "requires": {
-            "debug": "^4.3.4"
-          }
-        },
         "aggregate-error": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -33192,15 +32287,6 @@
           "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
           "requires": {
             "lru-cache": "^7.5.1"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
-          "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
-          "requires": {
-            "agent-base": "^7.0.2",
-            "debug": "4"
           }
         },
         "human-signals": {
@@ -34835,14 +33921,6 @@
             "mimic-fn": "^4.0.0"
           }
         },
-        "p-filter": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-          "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-          "requires": {
-            "p-map": "^2.0.0"
-          }
-        },
         "p-limit": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -34858,11 +33936,6 @@
           "requires": {
             "p-limit": "^4.0.0"
           }
-        },
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
         },
         "p-reduce": {
           "version": "3.0.0",
@@ -34941,11 +34014,6 @@
           "requires": {
             "crypto-random-string": "^2.0.0"
           }
-        },
-        "url-join": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-          "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
         },
         "yocto-queue": {
           "version": "1.0.0",
@@ -35869,9 +34937,9 @@
       }
     },
     "url-join": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aensley/semantic-release-openapi": "^1.1.8",
-        "@semantic-release/commit-analyzer": "^10.0.0",
+        "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^9.0.0",
@@ -57,7 +57,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "semantic-release": ">=20.1.0"
+        "semantic-release": ">= 19.0.3"
       }
     },
     "node_modules/@aensley/semantic-release-openapi": {
@@ -135,26 +135,6 @@
       "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
       "dependencies": {
         "@octokit/openapi-types": "^17.2.0"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@semantic-release/commit-analyzer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
-      "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
-        "debug": "^4.0.0",
-        "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
       }
     },
     "node_modules/@aensley/semantic-release-openapi/node_modules/@semantic-release/github": {
@@ -5183,23 +5163,23 @@
       "hasInstallScript": true
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.0.tgz",
-      "integrity": "sha512-/Uolz2+G+VRjP0eudAn0ldnC/VkSHzlctUdeEXL7ys7E6mLSFZdwdsR5pKDlTIgDJq4eYlshOZpwBNrmqrNajg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
       "dependencies": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.4",
         "micromatch": "^4.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14.17"
       },
       "peerDependencies": {
-        "semantic-release": ">=20.1.0"
+        "semantic-release": ">=18.0.0-beta.1"
       }
     },
     "node_modules/@semantic-release/error": {
@@ -16597,26 +16577,6 @@
         "@octokit/openapi-types": "^17.2.0"
       }
     },
-    "node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
-      "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
-        "debug": "^4.0.0",
-        "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
-      }
-    },
     "node_modules/semantic-release/node_modules/@semantic-release/github": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
@@ -21313,20 +21273,6 @@
             "@octokit/openapi-types": "^17.2.0"
           }
         },
-        "@semantic-release/commit-analyzer": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-          "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
-          "requires": {
-            "conventional-changelog-angular": "^5.0.0",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.2.3",
-            "debug": "^4.0.0",
-            "import-from": "^4.0.0",
-            "lodash": "^4.17.4",
-            "micromatch": "^4.0.2"
-          }
-        },
         "@semantic-release/github": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
@@ -24949,16 +24895,16 @@
       "integrity": "sha512-VGbKDbk1RFIaSmdVb0cNjjWJoRWRI/Weo23AjRCC2nryO0iAS8pzsToJfPVPtVs74WHw4L1UTADNdIYRLkirZQ=="
     },
     "@semantic-release/commit-analyzer": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.0.tgz",
-      "integrity": "sha512-/Uolz2+G+VRjP0eudAn0ldnC/VkSHzlctUdeEXL7ys7E6mLSFZdwdsR5pKDlTIgDJq4eYlshOZpwBNrmqrNajg==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
+      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
         "conventional-commits-parser": "^3.2.3",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.4",
         "micromatch": "^4.0.2"
       }
     },
@@ -32977,20 +32923,6 @@
           "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
           "requires": {
             "@octokit/openapi-types": "^17.2.0"
-          }
-        },
-        "@semantic-release/commit-analyzer": {
-          "version": "9.0.2",
-          "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-          "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
-          "requires": {
-            "conventional-changelog-angular": "^5.0.0",
-            "conventional-commits-filter": "^2.0.0",
-            "conventional-commits-parser": "^3.2.3",
-            "debug": "^4.0.0",
-            "import-from": "^4.0.0",
-            "lodash": "^4.17.4",
-            "micromatch": "^4.0.2"
           }
         },
         "@semantic-release/github": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Turo semantic-release configuration",
   "dependencies": {
     "@aensley/semantic-release-openapi": "^1.1.8",
-    "@semantic-release/commit-analyzer": "^10.0.0",
+    "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^9.0.0",
+    "@semantic-release/github": "^8.0.7",
     "@semantic-release/npm": "^10.0.0",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "conventional-changelog-conventionalcommits": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "main": "lib/index.js",
   "name": "@open-turo/semantic-release-config",
   "peerDependencies": {
-    "semantic-release": ">=20.1.0"
+    "semantic-release": ">= 19.0.3"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Reverts open-turo/semantic-release-config#116

`@cycjimmy/semantic-release-action@3.4.2` requires "semantic-release": "^19.0.5" requires 19 major version. 

This is blocking release in repos like:
```
npm ERR! While resolving: @cycjimmy/semantic-release-action@3.4.2
npm ERR! Found: semantic-release@19.0.5
npm ERR! node_modules/semantic-release
npm ERR!   semantic-release@"^19.0.5" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer semantic-release@">=20.1.0" from @open-turo/semantic-release-config@2.0.0
npm ERR! node_modules/@open-turo/semantic-release-config
npm ERR!   @open-turo/semantic-release-config@"*" from the root project
```
reverting will set the requirement back to any version greater than "semantic-release": ">= 19.0.3"