### PR TITLE
Use consistent parserOpts for commit-analyzer and release-notes-generator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,6 @@ export = {
     [
       "@semantic-release/release-notes-generator",
       {
-        parserOpts: {
-          noteKeywords: ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"],
-        },
         preset: "conventionalcommits",
         presetConfig: {
           types: [

--- a/test/__snapshots__/_config.test.ts.snap
+++ b/test/__snapshots__/_config.test.ts.snap
@@ -16,13 +16,6 @@ exports[`config createPreset creates a preset including the default config 1`] =
     [
       "@semantic-release/release-notes-generator",
       {
-        "parserOpts": {
-          "noteKeywords": [
-            "BREAKING CHANGE",
-            "BREAKING CHANGES",
-            "BREAKING",
-          ],
-        },
         "preset": "conventionalcommits",
         "presetConfig": {
           "types": [


### PR DESCRIPTION
As per slack findings, we are passing these options to the release-notes-generator, but not to the commit-analyzer, which is why when using `BREAKING` or `BREAKING CHANGES`, you would see correct release notes but the version still ended up as a minor

After discussing this with @tagoro9 offline, we agreed to let both the commit-analyzer and the release-notes-generator use the default parserOpts