### PR TITLE
Only use semantic-release/git in NPM preset in default branches

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,7 @@ const config = {
     "~test/*": ["./test/*"],
   },
   preset: "ts-jest",
+  setupFilesAfterEnv: ["<rootDir>test/setup-tests.ts"],
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@semantic-release/npm": "^11.0.2",
         "@semantic-release/release-notes-generator": "^12.1.0",
         "conventional-changelog-conventionalcommits": "^7.0.0",
-        "gradle-semantic-release-plugin": "^1.8.0"
+        "gradle-semantic-release-plugin": "^1.8.0",
+        "micromatch": "^4.0.5"
       },
       "devDependencies": {
         "@commitlint/cli": "18.6.0",
@@ -25,6 +26,7 @@
         "@open-turo/eslint-config-typescript": "7.0.0",
         "@types/jest": "29.5.12",
         "@types/lodash.template": "4.5.3",
+        "@types/micromatch": "^4.0.6",
         "@types/node": "20.11.17",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
@@ -5871,6 +5873,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.4.tgz",
+      "integrity": "sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -5939,6 +5947,15 @@
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.6.tgz",
+      "integrity": "sha512-2eulCHWqjEpk9/vyic4tBhI8a9qQEl6DaK2n/sF7TweX9YESlypgKyhXMDGt4DAOy/jhLPvVrZc8pTDAMsplJA==",
+      "dev": true,
+      "dependencies": {
+        "@types/braces": "*"
       }
     },
     "node_modules/@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@semantic-release/npm": "^11.0.2",
     "@semantic-release/release-notes-generator": "^12.1.0",
     "conventional-changelog-conventionalcommits": "^7.0.0",
-    "gradle-semantic-release-plugin": "^1.8.0"
+    "gradle-semantic-release-plugin": "^1.8.0",
+    "micromatch": "^4.0.5"
   },
   "devDependencies": {
     "@commitlint/cli": "18.6.0",
@@ -18,6 +19,7 @@
     "@open-turo/eslint-config-typescript": "7.0.0",
     "@types/jest": "29.5.12",
     "@types/lodash.template": "4.5.3",
+    "@types/micromatch": "^4.0.6",
     "@types/node": "20.11.17",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",

--- a/src/_config.ts
+++ b/src/_config.ts
@@ -48,14 +48,16 @@ const getPluginName = (plugin: SemanticReleasePlugin) => {
  * plugins that need to stay at the end remain there
  * @param plugins List of plugin configs for the preset
  */
-export function createPreset(plugins: SemanticReleasePlugin[]) {
+export function createPreset(
+  plugins: Array<SemanticReleasePlugin | undefined>,
+) {
   return {
     ...baseConfig,
     plugins: [
       ...baseConfig.plugins.filter(
         (p) => !pluginsThatGoAtTheEnd.has(getPluginName(p)),
       ),
-      ...plugins,
+      ...plugins.filter((plugin) => plugin !== undefined),
       ...baseConfig.plugins.filter((p) =>
         pluginsThatGoAtTheEnd.has(getPluginName(p)),
       ),

--- a/src/_config.ts
+++ b/src/_config.ts
@@ -26,10 +26,9 @@ export function semanticReleaseGit(
     ? "ci(release): ${nextRelease.version}\n\n${nextRelease.notes}"
     : "ci(release): ${nextRelease.version} <% nextRelease.channel !== 'next' ? print('[skip ci]') : print('') %>\n\n${nextRelease.notes}";
 
-  if (
-    !process.env.GITHUB_REF ||
-    micromatch.isMatch(process.env.GITHUB_REF || "", baseConfig.branches)
-  ) {
+  // Split refs/heads/branch-name to branch-name. I running in a pull request, then we don't care
+  const branch = process.env.GITHUB_REF?.split("/").pop();
+  if (!branch || micromatch.isMatch(branch || "", baseConfig.branches)) {
     return [
       "@semantic-release/git",
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  *
  * The release notes will include all the commits and not just the commits that trigger a release.
  */
+
 export = {
   branches: ["main", "+([0-9])?(.{+([0-9]),x}).x"],
   plugins: [

--- a/test/_config.test.ts
+++ b/test/_config.test.ts
@@ -1,22 +1,24 @@
-import {
-  createPreset,
-  semanticReleaseGit,
-  SemanticReleasePlugin,
-} from "~/_config";
-import npm from "~/npm";
 import template = require("lodash.template");
+import { SemanticReleasePlugin } from "~/_config";
 
 describe("config", () => {
+  let config: typeof import("~/_config");
+
+  beforeEach(async () => {
+    config = await import("~/_config");
+  });
+
   describe("createPreset", () => {
     let preset: { plugins: SemanticReleasePlugin[] };
     beforeEach(() => {
-      preset = createPreset(["a", "b"]);
+      preset = config.createPreset(["a", "b"]);
     });
     test("creates a preset including the default config", () => {
       expect(preset).toMatchSnapshot();
     });
 
-    test("@semantic-release/exec is the last plugin", () => {
+    test("@semantic-release/exec is the last plugin", async () => {
+      const npm = await import("~/npm");
       expect(preset.plugins[npm.plugins.length - 1][0]).toBe(
         "@semantic-release/exec",
       );
@@ -28,7 +30,7 @@ describe("config", () => {
       "semantic-release/@git generates the right commit message for channel %s",
       (channel) => {
         const assets = ["a"];
-        const gitPlugin = semanticReleaseGit(assets);
+        const gitPlugin = config.semanticReleaseGit(assets);
         const pluginConfig = ((gitPlugin && gitPlugin[1]) || {
           assets: [],
           message: "",

--- a/test/_config.test.ts
+++ b/test/_config.test.ts
@@ -19,9 +19,7 @@ describe("config", () => {
 
     test("@semantic-release/exec is the last plugin", async () => {
       const npm = await import("~/npm");
-      expect(preset.plugins[npm.plugins.length - 1][0]).toBe(
-        "@semantic-release/exec",
-      );
+      expect(npm.plugins.at(-1)![0]).toBe("@semantic-release/exec");
     });
   });
 

--- a/test/gradle.test.ts
+++ b/test/gradle.test.ts
@@ -1,7 +1,6 @@
-import gradle from "~/gradle";
-
 describe("gradle", () => {
-  test("adds gradle-semantic-release-plugin and semantic-release/git plugins", () => {
+  test("adds gradle-semantic-release-plugin and semantic-release/git plugins", async () => {
+    const gradle = await import("~/gradle");
     const gradlePlugin = gradle.plugins[3];
     const semanticReleasePlugin = gradle.plugins[4];
     expect(gradlePlugin).toMatchSnapshot();

--- a/test/npm.test.ts
+++ b/test/npm.test.ts
@@ -1,10 +1,23 @@
-import npm from "~/npm";
-
 describe("npm", () => {
-  test("adds npm and semantic-release/git plugins", () => {
+  afterEach(() => {
+    delete process.env.GITHUB_REF;
+  });
+
+  test("adds npm and semantic-release/git plugins", async () => {
+    const npm = await import("~/npm");
+    expect(npm.plugins).toHaveLength(6);
     const npmPlugin = npm.plugins[3];
     const semanticReleasePlugin = npm.plugins[4];
     expect(npmPlugin).toMatchSnapshot();
     expect(semanticReleasePlugin).toMatchSnapshot();
   });
+
+  test.each(["ref/heads/test", "ref/pulls/1/merge"])(
+    "does not add npm and semantic-release/git plugins when not running on a default branch",
+    async (branch) => {
+      process.env.GITHUB_REF = branch;
+      const npm = await import("~/npm");
+      expect(npm.plugins).toHaveLength(5);
+    },
+  );
 });

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -1,7 +1,6 @@
-import openapi from "~/openapi";
-
 describe("openapi", () => {
-  test("adds gradle-semantic-release-plugin, semantic-release/git, and semantic-release-openapi plugins", () => {
+  test("adds gradle-semantic-release-plugin, semantic-release/git, and semantic-release-openapi plugins", async () => {
+    const openapi = await import("~/openapi");
     const gradlePlugin = openapi.plugins[3];
     const openApiPlugin = openapi.plugins[4];
     const semanticReleasePlugin = openapi.plugins[5];

--- a/test/setup-tests.ts
+++ b/test/setup-tests.ts
@@ -1,4 +1,15 @@
+const originalEnvironment = process.env;
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = {
+    ...originalEnvironment,
+    GITHUB_REF: "refs/head/main",
+  };
+});
+
 afterEach(() => {
+  process.env = originalEnvironment;
   jest.resetModules();
   jest.restoreAllMocks();
 });

--- a/test/setup-tests.ts
+++ b/test/setup-tests.ts
@@ -1,0 +1,4 @@
+afterEach(() => {
+  jest.resetModules();
+  jest.restoreAllMocks();
+});


### PR DESCRIPTION
**Description**

When we trigger releases in PRs from https://github.com/open-turo/actions-release/tree/main/semantic-release anything committed to git ends up producing noise and requires a dev to go and undo the commits.

This PR adds support in the NPM preset to only do that when running on the default branches (main and maintenance branches).

Created `6.1.0-pr-167.151.1.1` to test the new setup

**TODOs**

- [x] Test that this works as expected and that the env var is available via the action

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
