### PR TITLE
fix: reduce number of calls to Github API to avoid hitting rate limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,16 @@ export = {
         },
       },
     ],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        failComment: false,
+        failTitle: false,
+        labels: false,
+        releasedLabels: false,
+        successComment: false,
+      },
+    ],
     [
       "@semantic-release/exec",
       {

--- a/test/__snapshots__/_config.test.ts.snap
+++ b/test/__snapshots__/_config.test.ts.snap
@@ -74,7 +74,16 @@ exports[`config createPreset creates a preset including the default config 1`] =
         },
       },
     ],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        "failComment": false,
+        "failTitle": false,
+        "labels": false,
+        "releasedLabels": false,
+        "successComment": false,
+      },
+    ],
     "a",
     "b",
     [


### PR DESCRIPTION

**Description**

We are starting to hit some secondary rate limits when using this module. This PR disables some of the Github release features to avoid making so many github API calls.

The one that we could bring back is the `successComment` one, as that is usually useful. The others we can disable since we don't use issues typically to control releases.

**Changes**

* fix: reduce number of calls to Github API to avoid hitting rate limits

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
