### PR TITLE
fix: allow releases on master

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 export = {
-  branches: ["main", "+([0-9])?(.{+([0-9]),x}).x"],
+  branches: ["main", "master", "+([0-9])?(.{+([0-9]),x}).x"],
   plugins: [
     "@semantic-release/commit-analyzer",
     // We want to use the angular preset, but we want to include all commits in the changelog

--- a/test/__snapshots__/_config.test.ts.snap
+++ b/test/__snapshots__/_config.test.ts.snap
@@ -4,6 +4,7 @@ exports[`config createPreset creates a preset including the default config 1`] =
 {
   "branches": [
     "main",
+    "master",
     "+([0-9])?(.{+([0-9]),x}).x",
   ],
   "plugins": [


### PR DESCRIPTION

**Description**

There are still repos that use `master` as their default branch.

**Changes**

* fix: allow releases on master

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
