### PR TITLE
fix: downgrade conventional-changelog-conventionalcommits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@semantic-release/github": "^10.0.3",
         "@semantic-release/npm": "^12.0.0",
         "@semantic-release/release-notes-generator": "^13.0.0",
-        "conventional-changelog-conventionalcommits": "^8.0.0",
+        "conventional-changelog-conventionalcommits": "^7.0.2",
         "gradle-semantic-release-plugin": "^1.9.1",
         "micromatch": "^4.0.5"
       },
@@ -6866,14 +6866,14 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@semantic-release/github": "^10.0.3",
     "@semantic-release/npm": "^12.0.0",
     "@semantic-release/release-notes-generator": "^13.0.0",
-    "conventional-changelog-conventionalcommits": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
     "gradle-semantic-release-plugin": "^1.9.1",
     "micromatch": "^4.0.5"
   },


### PR DESCRIPTION

**Description**

This is breaking semantic-release.

See https://github.com/semantic-release/release-notes-generator/issues/633

**Changes**

* fix: downgrade conventional-changelog-conventionalcommits

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
