### PR TITLE
feat(openapi): add support to conditionally enable plugins

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,24 @@
+name: Prerelease
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - synchronize
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  prerelease:
+    name: Prerelease
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'prerelease')
+    steps:
+      - name: Prerelease
+        id: prerelease
+        uses: open-turo/actions-node/prerelease@v6
+        with:
+          github-token: ${{ secrets.OPEN_TURO_GITHUB_TOKEN }}
+          npm-token: ${{ secrets.OPEN_TURO_NPM_TOKEN }}
+          create-prerelease: true

--- a/src/_config.ts
+++ b/src/_config.ts
@@ -16,7 +16,7 @@ const pluginsThatGoAtTheEnd = new Set(["@semantic-release/exec"]);
  * Return the configuration for the @semantic-release/git plugin to commit
  * changes in the specified assets
  * @param assets List of assets to commit
- * @param requireCI to controll when commit requires ci check
+ * @param requireCI to control when commit requires ci check
  */
 export function semanticReleaseGit(
   assets: string[],
@@ -26,7 +26,7 @@ export function semanticReleaseGit(
     ? "ci(release): ${nextRelease.version}\n\n${nextRelease.notes}"
     : "ci(release): ${nextRelease.version} <% nextRelease.channel !== 'next' ? print('[skip ci]') : print('') %>\n\n${nextRelease.notes}";
 
-  // Split refs/heads/branch-name to branch-name. I running in a pull request, then we don't care
+  // Split refs/heads/branch-name to branch-name. If running in a pull request, then we don't care
   const branch = process.env.GITHUB_REF?.split("/").pop();
   if (!branch || micromatch.isMatch(branch || "", baseConfig.branches)) {
     return [

--- a/src/_config.ts
+++ b/src/_config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import * as process from "node:process";
 
 import micromatch from "micromatch";
@@ -51,6 +52,38 @@ const getPluginName = (plugin: SemanticReleasePlugin) => {
   }
   return plugin[0];
 };
+
+/**
+ * Check if a file is in the Git repository
+ * @param filePath Path to the file
+ * @param repoPath Path to the Git repository
+ */
+function doesGitRepoContainFile(filePath: string, repoPath = process.cwd()) {
+  try {
+    // eslint-disable-next-line sonarjs/os-command
+    execSync(`git cat-file -e HEAD:${filePath}`, {
+      cwd: repoPath,
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Conditionally create a semantic release plugin if any of the specified files exist in the Git repository
+ * @param files List of files to check
+ * @param plugin Plugin to create
+ */
+export function createPluginIfFilesExist(
+  files: string[],
+  plugin: SemanticReleasePlugin,
+): SemanticReleasePlugin | undefined {
+  return files.some((file) => doesGitRepoContainFile(file))
+    ? plugin
+    : undefined;
+}
 
 /**
  * Create a preset that extends the default configuration ensuring that

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,4 +1,5 @@
 import {
+  createPluginIfFilesExist,
   createPreset,
   semanticReleaseGit,
   type SemanticReleasePlugin,
@@ -18,13 +19,30 @@ const semanticReleaseOpenApi = (
 };
 
 /**
- * Semantic release configuration preset for OpenAPI projects. It adds the gradle-semantic-release-plugin,
- * the semantic-release-openapi plugin, and ensures that the gradle.properties file and swagger spec gets committed
+ * Semantic release configuration preset for OpenAPI projects. It adds the semantic-release-openapi plugin,
+ * and conditionally the npm and gradle plugins based on the presence of relevant files.
  */
 export = createPreset([
-  // Ideally we would be able to use some sort of composite preset since OpenAPI doesn't necessarily mean gradle.
-  // But we use the OpenAPI gradle plugin to generate specs and gradle to publish artifacts so this plugin needs to be defined here.
-  "gradle-semantic-release-plugin",
+  createPluginIfFilesExist(
+    ["build.gradle", "build.gradle.kts"],
+    "gradle-semantic-release-plugin",
+  ),
+  createPluginIfFilesExist(
+    ["package.json"],
+    [
+      "@semantic-release/npm",
+      {
+        tarballDir: "pack",
+      },
+    ],
+  ),
   semanticReleaseOpenApi([openApiSpecGlob]),
-  semanticReleaseGit(["gradle.properties", "README.md", openApiSpecGlob]),
+  semanticReleaseGit([
+    "README.md",
+    "gradle.properties",
+    "package-lock.json",
+    "package.json",
+    "yarn.lock",
+    openApiSpecGlob,
+  ]),
 ]);

--- a/test/__snapshots__/openapi.test.ts.snap
+++ b/test/__snapshots__/openapi.test.ts.snap
@@ -1,8 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`openapi adds gradle-semantic-release-plugin, semantic-release/git, and semantic-release-openapi plugins 1`] = `"gradle-semantic-release-plugin"`;
+exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins 1`] = `"gradle-semantic-release-plugin"`;
 
-exports[`openapi adds gradle-semantic-release-plugin, semantic-release/git, and semantic-release-openapi plugins 2`] = `
+exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins 2`] = `
+[
+  "@semantic-release/npm",
+  {
+    "tarballDir": "pack",
+  },
+]
+`;
+
+exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins 3`] = `
 [
   "@aensley/semantic-release-openapi",
   {
@@ -13,13 +22,16 @@ exports[`openapi adds gradle-semantic-release-plugin, semantic-release/git, and 
 ]
 `;
 
-exports[`openapi adds gradle-semantic-release-plugin, semantic-release/git, and semantic-release-openapi plugins 3`] = `
+exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins 4`] = `
 [
   "@semantic-release/git",
   {
     "assets": [
-      "gradle.properties",
       "README.md",
+      "gradle.properties",
+      "package-lock.json",
+      "package.json",
+      "yarn.lock",
       "spec/**/*.yaml",
     ],
     "message": "ci(release): \${nextRelease.version} <% nextRelease.channel !== 'next' ? print('[skip ci]') : print('') %>

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -1,10 +1,19 @@
+import { execSync } from "node:child_process";
+
+jest.mock("node:child_process", () => ({
+  execSync: jest.fn(),
+}));
+
 describe("openapi", () => {
-  test("adds gradle-semantic-release-plugin, semantic-release/git, and semantic-release-openapi plugins", async () => {
+  test("adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins", async () => {
+    (execSync as jest.Mock).mockImplementation(() => {});
     const openapi = await import("~/openapi");
     const gradlePlugin = openapi.plugins[3];
-    const openApiPlugin = openapi.plugins[4];
-    const semanticReleasePlugin = openapi.plugins[5];
+    const npmPlugin = openapi.plugins[4];
+    const openApiPlugin = openapi.plugins[5];
+    const semanticReleasePlugin = openapi.plugins[6];
     expect(gradlePlugin).toMatchSnapshot();
+    expect(npmPlugin).toMatchSnapshot();
     expect(openApiPlugin).toMatchSnapshot();
     expect(semanticReleasePlugin).toMatchSnapshot();
   });


### PR DESCRIPTION

**Description**

This PR adds support to conditionally enable certain plugins on the openapi preseet:

- Enable NPM plugin if we find a `package.json`
- Enable the gradle plugin if we find a `build.gradle` or `build.gradle.kts` file

This was a long standing issue in this preset and we just run into an issue where we need to run both npm and gradle releases for an openapi spec.

It also makes some improvements to CI so we can test this better.

**Changes**

- docs: fix some typos
- feat: add function to conditionally create plugins if files exist in repo
- feat(openapi): enable gradle and npm plugins conditionally
- ci: add prerelease workflow

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
