### PR TITLE
Combine gradle and npm for non openapi repos

### DIFF
--- a/src/gradle-and-npm.ts
+++ b/src/gradle-and-npm.ts
@@ -1,0 +1,37 @@
+/**
+ * A `.releaserc.json` cannot specify `/gradle` and `/npm` as separate plugins and run both.
+ * This file allows us to run both behind `/gradleAndNpm`.
+ */
+
+import {
+  createPluginIfFilesExist,
+  createPreset,
+  semanticReleaseGit,
+} from "~/_config";
+
+/**
+ * Semantic release configuration preset for OpenAPI projects. It adds the semantic-release-openapi plugin,
+ * and conditionally the npm and gradle plugins based on the presence of relevant files.
+ */
+export = createPreset([
+  createPluginIfFilesExist(
+    ["build.gradle", "build.gradle.kts"],
+    "gradle-semantic-release-plugin",
+  ),
+  createPluginIfFilesExist(
+    ["package.json"],
+    [
+      "@semantic-release/npm",
+      {
+        tarballDir: "pack",
+      },
+    ],
+  ),
+  semanticReleaseGit([
+    "README.md",
+    "gradle.properties",
+    "package-lock.json",
+    "package.json",
+    "yarn.lock",
+  ]),
+]);

--- a/test/__snapshots__/gradle-and-npm.test.ts.snap
+++ b/test/__snapshots__/gradle-and-npm.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gradle-and-npm adds gradle-semantic-release-plugin, semantic-release/npm, and semantic-release/git plugins 1`] = `"gradle-semantic-release-plugin"`;
+
+exports[`gradle-and-npm adds gradle-semantic-release-plugin, semantic-release/npm, and semantic-release/git plugins 2`] = `
+[
+  "@semantic-release/npm",
+  {
+    "tarballDir": "pack",
+  },
+]
+`;
+
+exports[`gradle-and-npm adds gradle-semantic-release-plugin, semantic-release/npm, and semantic-release/git plugins 3`] = `
+[
+  "@semantic-release/git",
+  {
+    "assets": [
+      "README.md",
+      "gradle.properties",
+      "package-lock.json",
+      "package.json",
+      "yarn.lock",
+    ],
+    "message": "ci(release): \${nextRelease.version} <% nextRelease.channel !== 'next' ? print('[skip ci]') : print('') %>
+
+\${nextRelease.notes}",
+  },
+]
+`;
+
+exports[`gradle-and-npm adds gradle-semantic-release-plugin, semantic-release/npm, and semantic-release/git plugins 4`] = `
+[
+  "@semantic-release/exec",
+  {
+    "failCmd": "[ -x ./script/semantic-release-fail ] && ./script/semantic-release-fail '\${nextRelease.version}' || true",
+    "publishCmd": "[ -x ./script/semantic-release-publish ] && ./script/semantic-release-publish '\${nextRelease.version}' || true",
+    "successCmd": "[ -x ./script/semantic-release-success ] && ./script/semantic-release-success '\${nextRelease.version}' || true",
+  },
+]
+`;

--- a/test/gradle-and-npm.test.ts
+++ b/test/gradle-and-npm.test.ts
@@ -1,0 +1,20 @@
+import { execSync } from "node:child_process";
+
+jest.mock("node:child_process", () => ({
+  execSync: jest.fn(),
+}));
+
+describe("gradle-and-npm", () => {
+  test("adds gradle-semantic-release-plugin, semantic-release/npm, and semantic-release/git plugins", async () => {
+    (execSync as jest.Mock).mockImplementation(() => {});
+    const openapi = await import("~/gradle-and-npm");
+    const gradlePlugin = openapi.plugins[3];
+    const npmPlugin = openapi.plugins[4];
+    const openApiPlugin = openapi.plugins[5];
+    const semanticReleasePlugin = openapi.plugins[6];
+    expect(gradlePlugin).toMatchSnapshot();
+    expect(npmPlugin).toMatchSnapshot();
+    expect(openApiPlugin).toMatchSnapshot();
+    expect(semanticReleasePlugin).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
We created the `openapi` file to solve for a problem where we wanted to run both `gradle` and `npm`, but we can't specify multiple `.releaserc.json` entries and have them both run. That file is specific to OpenAPI, however. This new file is separate from OpenAPI, but is intended to be run in a Lerna-managed monorepo that builds using both `gradle` and `npm`. 