### PR TITLE
feat: replace @aensley/semantic-release-openapi with semantic-release-openapi

### DIFF
--- a/docs/breaking-changes/v9.md
+++ b/docs/breaking-changes/v9.md
@@ -1,0 +1,3 @@
+# Breaking changes in v9
+
+- `@aensley/semantic-release-openapi` dependency now just `semantic-release-openapi`. Cutting a new major for visibility into this change so that all usages update references where we are explicitly looking up `@aensley/semantic-release-openapi`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "8.2.3",
       "license": "MIT",
       "dependencies": {
-        "@aensley/semantic-release-openapi": "1.4.1",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/exec": "^7.0.0",
         "@semantic-release/git": "^10.0.1",
@@ -18,7 +17,8 @@
         "@semantic-release/release-notes-generator": "^14.0.1",
         "conventional-changelog-conventionalcommits": "^9.0.0",
         "gradle-semantic-release-plugin": "^1.10.0",
-        "micromatch": "^4.0.5"
+        "micromatch": "^4.0.5",
+        "semantic-release-openapi": "1.5.1"
       },
       "devDependencies": {
         "@open-turo/eslint-config-typescript": "17.0.12",
@@ -44,65 +44,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=24"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@aensley/semantic-release-openapi/-/semantic-release-openapi-1.4.1.tgz",
-      "integrity": "sha512-37DkoiseoKXqwHO6Bg/eSqr7kcRtHsNALEJ2nvVwBJs0lrFE1prQplOxgeTAnX7gJw7LGTaPpIJ3OJMB01zW7Q==",
-      "deprecated": "Please use new descoped package 'semantic-release-openapi': https://www.npmjs.com/package/semantic-release-openapi",
-      "funding": [
-        "https://github.com/sponsors/aensley",
-        "https://paypal.me/AndrewEnsley"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^4.0.0",
-        "fdir": "^6.4.6",
-        "fs-extra": "^11.3.0",
-        "picomatch": "^4.0.2",
-        "replace-in-file": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=20.0.0"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/@semantic-release/error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aensley/semantic-release-openapi/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12654,6 +12595,64 @@
       },
       "engines": {
         "node": ">=20.8.1"
+      }
+    },
+    "node_modules/semantic-release-openapi": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/semantic-release-openapi/-/semantic-release-openapi-1.5.1.tgz",
+      "integrity": "sha512-hv5/LDcDAsAILP0T29YBkxMv7+HauGueMnL1ayDEGuFQaRVXv4r2AOD0D4Eab89/hOXnxv36oTckHgZkB6vbNw==",
+      "funding": [
+        "https://github.com/sponsors/aensley",
+        "https://paypal.me/AndrewEnsley"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "fdir": "^6.4.6",
+        "fs-extra": "^11.3.0",
+        "picomatch": "^4.0.2",
+        "replace-in-file": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20.0.0"
+      }
+    },
+    "node_modules/semantic-release-openapi/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release-openapi/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/semantic-release-openapi/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/semantic-release/node_modules/@semantic-release/error": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "author": "Turo engineering",
   "description": "Turo semantic-release configuration",
   "dependencies": {
-    "@aensley/semantic-release-openapi": "1.4.1",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/exec": "^7.0.0",
     "@semantic-release/git": "^10.0.1",
@@ -11,7 +10,8 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "gradle-semantic-release-plugin": "^1.10.0",
-    "micromatch": "^4.0.5"
+    "micromatch": "^4.0.5",
+    "semantic-release-openapi": "1.5.1"
   },
   "devDependencies": {
     "@open-turo/eslint-config-typescript": "17.0.12",

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -11,7 +11,7 @@ const semanticReleaseOpenApi = (
   apiSpecFiles: string[],
 ): SemanticReleasePlugin => {
   return [
-    "@aensley/semantic-release-openapi",
+    "semantic-release-openapi",
     {
       apiSpecFiles,
     },

--- a/test/__snapshots__/openapi.test.ts.snap
+++ b/test/__snapshots__/openapi.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins 1`] = `"gradle-semantic-release-plugin"`;
 
@@ -13,7 +13,7 @@ exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, sema
 
 exports[`openapi adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins 3`] = `
 [
-  "@aensley/semantic-release-openapi",
+  "semantic-release-openapi",
   {
     "apiSpecFiles": [
       "spec/**/*.yaml",


### PR DESCRIPTION
BREAKING CHANGE: new namespace requires updating any old references to continue receiving updates

Issue: we are seeing errors in CI due to a bug in the underlying dependency:

```
[5:59:27 PM] [semantic-release] › ✘  An error occurred while running semantic-release: file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/@aensley/semantic-release-openapi/dist/prepare.js:1
import { readJsonSync, writeJsonSync } from 'fs-extra';
         ^^^^^^^^^^^^
SyntaxError: Named export 'readJsonSync' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'fs-extra';
const { readJsonSync, writeJsonSync } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:180:21)
    at ModuleJob.run (node:internal/modules/esm/module_job:263:5)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at loadPlugin (file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/lib/plugins/utils.js:60:54)
    at file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/lib/plugins/index.js:18:37
    at file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/lib/plugins/index.js:15:29
    at file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/lib/plugins/index.js:15:29
    at default (file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/lib/plugins/index.js:14:7)
    at default (file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/lib/get-config.js:92:30)
    at default (file:///opt/actions-runner/_work/_actions/open-turo/actions-release/v5/semantic-release/dist/node_modules/semantic-release/index.js:274:34)
Error: SyntaxError: Named export 'readJsonSync' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
```

This was fixed upstream: https://github.com/aensley/semantic-release-openapi/pull/51

But we are not receiving updates about a new dependency because `1.4.1` was the last release under the old namespace. We replace it with the new dependency name, and mark it as breaking for visibility.