### PR TITLE
f/add-semantic-release-jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ of the plugins to work correctly.
 #### Default
 
 - `GITHUB_TOKEN`. A GitHub token so the Github release can be created
+- `SEMANTIC_RELEASE_JIRA_SERVER_URL`. Jira instance URL (e.g. `https://your-company.atlassian.net`). When unset, the
+  Jira plugin is a noop. See [Jira integration](#jira-integration) below.
+- `SEMANTIC_RELEASE_JIRA_USERNAME` / `SEMANTIC_RELEASE_JIRA_API_TOKEN`. Optional. Required only for write
+  operations (issue transitions, version creation) and to fetch issue titles for release notes.
 
 #### Gradle
 
@@ -72,6 +76,27 @@ of the plugins to work correctly.
 - `GITHUB_TOKEN`. When a new release is published, this plugin will try to commit and push into the released branch.
   Ensure that the user that is running the release has push rights and can bypass branch
   protection rules (see [here](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule))
+
+### Jira integration
+
+All presets include [@open-turo/semantic-release-jira](https://github.com/open-turo/semantic-release-jira),
+which collects Jira issue references from commits, branch names, and PR descriptions, and appends a
+`## Jira Issues` section to the release notes.
+
+The plugin is configured entirely via environment variables (no configuration is provided in this preset), so
+each consuming repository can opt into the level of integration it needs:
+
+- **Disabled (noop)**. Don't set any `SEMANTIC_RELEASE_JIRA_*` variables. The plugin runs but does nothing.
+- **Read-only**. Set `SEMANTIC_RELEASE_JIRA_SERVER_URL`. Issue keys in commits / branches / PRs are linked
+  in the release notes.
+- **Authenticated read**. Also set `SEMANTIC_RELEASE_JIRA_USERNAME` and `SEMANTIC_RELEASE_JIRA_API_TOKEN`.
+  Release notes include issue titles in addition to links.
+- **Write mode**. Add `SEMANTIC_RELEASE_JIRA_TRANSITION_ISSUES=true` to move issues to `Done`, and/or
+  `SEMANTIC_RELEASE_JIRA_CREATE_VERSIONS=true` to create Jira versions. Write operations only run on default
+  branch releases (skips prereleases).
+
+See the [plugin README](https://github.com/open-turo/semantic-release-jira#readme) for the full list of
+supported environment variables.
 
 ### @semantic-release/exec
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aensley/semantic-release-openapi": "1.1.8",
+        "@open-turo/semantic-release-jira": "^1.0.2",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
@@ -4190,6 +4191,33 @@
         "@octokit/core": ">=6"
       }
     },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
     "node_modules/@octokit/plugin-retry": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-8.0.3.tgz",
@@ -4246,6 +4274,21 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
       },
       "engines": {
         "node": ">= 20"
@@ -4308,6 +4351,58 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@open-turo/semantic-release-jira": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@open-turo/semantic-release-jira/-/semantic-release-jira-1.0.2.tgz",
+      "integrity": "sha512-NWNfuBQy9fJzoELPdx63LfgIyg2sXuFSi5xRkaUWpp7pgtZpJk7xmvq53Fx7wH521QeVAvMpujQfALBwmmPBhQ==",
+      "license": "MIT",
+      "workspaces": [
+        "semantic-release"
+      ],
+      "dependencies": {
+        "@octokit/rest": "^22.0.0",
+        "axios": "^1.7.9",
+        "axios-retry": "^4.5.0",
+        "conventional-commits-parser": "^6.0.0",
+        "fast-redact": "^3.5.0",
+        "p-limit": "^7.2.0",
+        "safe-regex": "^2.1.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=23.0.0"
+      }
+    },
+    "node_modules/@open-turo/semantic-release-jira/node_modules/p-limit": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@open-turo/semantic-release-jira/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -6304,6 +6399,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -6318,6 +6419,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -6438,7 +6588,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6722,6 +6871,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -7237,6 +7398,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -7304,7 +7474,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7602,7 +7771,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7612,7 +7780,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7629,7 +7796,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7642,7 +7808,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8581,6 +8746,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -8696,6 +8870,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -8710,6 +8904,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/from": {
@@ -8868,7 +9078,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8893,7 +9102,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -9074,7 +9282,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9196,7 +9403,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9209,7 +9415,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9807,6 +10012,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -10718,7 +10935,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10777,6 +10993,27 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -13679,6 +13916,15 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "license": "ISC"
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ps-tree": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -14085,7 +14331,6 @@
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
       "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "regexp-tree": "bin/regexp-tree"
@@ -14452,6 +14697,15 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -16801,6 +17055,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Turo semantic-release configuration",
   "dependencies": {
     "@aensley/semantic-release-openapi": "1.1.8",
+    "@open-turo/semantic-release-jira": "^1.0.2",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
@@ -18,6 +19,7 @@
     "@types/lodash.template": "4.5.3",
     "@types/micromatch": "4.0.10",
     "@types/node": "25.0.3",
+    "@vitest/coverage-v8": "4.1.5",
     "eslint": "9.39.2",
     "lodash": "4.18.1",
     "prettier": "3.7.4",
@@ -28,8 +30,7 @@
     "tsc-watch": "7.2.0",
     "typescript": "6.0.3",
     "typescript-transform-paths": "3.5.6",
-    "vitest": "4.1.5",
-    "@vitest/coverage-v8": "4.1.5"
+    "vitest": "4.1.5"
   },
   "engines": {
     "node": ">= 20.8.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ const config = {
         },
       },
     ],
+    "@open-turo/semantic-release-jira",
     [
       "@semantic-release/github",
       {

--- a/test/__snapshots__/_config.test.ts.snap
+++ b/test/__snapshots__/_config.test.ts.snap
@@ -75,6 +75,7 @@ exports[`config > createPreset > creates a preset including the default config 1
         },
       },
     ],
+    "@open-turo/semantic-release-jira",
     [
       "@semantic-release/github",
       {

--- a/test/gradle-and-npm.test.ts
+++ b/test/gradle-and-npm.test.ts
@@ -9,10 +9,10 @@ describe("gradle-and-npm", () => {
   test("adds gradle-semantic-release-plugin, semantic-release/npm, and semantic-release/git plugins", async () => {
     vi.mocked(execSync).mockImplementation(() => "");
     const { default: gradleAndNpm } = await import("~/gradle-and-npm");
-    const gradlePlugin = gradleAndNpm.plugins[3];
-    const npmPlugin = gradleAndNpm.plugins[4];
-    const openApiPlugin = gradleAndNpm.plugins[5];
-    const semanticReleasePlugin = gradleAndNpm.plugins[6];
+    const gradlePlugin = gradleAndNpm.plugins[4];
+    const npmPlugin = gradleAndNpm.plugins[5];
+    const openApiPlugin = gradleAndNpm.plugins[6];
+    const semanticReleasePlugin = gradleAndNpm.plugins[7];
     expect(gradlePlugin).toMatchSnapshot();
     expect(npmPlugin).toMatchSnapshot();
     expect(openApiPlugin).toMatchSnapshot();

--- a/test/gradle.test.ts
+++ b/test/gradle.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from "vitest";
 describe("gradle", () => {
   test("adds gradle-semantic-release-plugin and semantic-release/git plugins", async () => {
     const { default: gradle } = await import("~/gradle");
-    const gradlePlugin = gradle.plugins[3];
-    const semanticReleasePlugin = gradle.plugins[4];
+    const gradlePlugin = gradle.plugins[4];
+    const semanticReleasePlugin = gradle.plugins[5];
     expect(gradlePlugin).toMatchSnapshot();
     expect(semanticReleasePlugin).toMatchSnapshot();
   });

--- a/test/npm.test.ts
+++ b/test/npm.test.ts
@@ -5,9 +5,9 @@ import type { SemanticReleasePlugin } from "~/_config";
 describe("npm", () => {
   test("adds npm and semantic-release/git plugins", async () => {
     const { default: npm } = await import("~/npm");
-    expect(npm.plugins).toHaveLength(6);
-    const npmPlugin = npm.plugins[3];
-    const semanticReleasePlugin = npm.plugins[4];
+    expect(npm.plugins).toHaveLength(7);
+    const npmPlugin = npm.plugins[4];
+    const semanticReleasePlugin = npm.plugins[5];
     expect(npmPlugin).toMatchSnapshot();
     expect(semanticReleasePlugin).toMatchSnapshot();
   });
@@ -26,7 +26,7 @@ describe("npm", () => {
       });
       process.env.GITHUB_REF = branch;
       const { default: npm } = await import("~/npm");
-      expect(npm.plugins).toHaveLength(5);
+      expect(npm.plugins).toHaveLength(6);
       delete process.env.GITHUB_REF;
     },
   );

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -9,10 +9,10 @@ describe("openapi", () => {
   test("adds gradle-semantic-release-plugin, semantic-release/npm, semantic-release/git, and semantic-release-openapi plugins", async () => {
     vi.mocked(execSync).mockImplementation(() => "");
     const { default: openapi } = await import("~/openapi");
-    const gradlePlugin = openapi.plugins[3];
-    const npmPlugin = openapi.plugins[4];
-    const openApiPlugin = openapi.plugins[5];
-    const semanticReleasePlugin = openapi.plugins[6];
+    const gradlePlugin = openapi.plugins[4];
+    const npmPlugin = openapi.plugins[5];
+    const openApiPlugin = openapi.plugins[6];
+    const semanticReleasePlugin = openapi.plugins[7];
     expect(gradlePlugin).toMatchSnapshot();
     expect(npmPlugin).toMatchSnapshot();
     expect(openApiPlugin).toMatchSnapshot();


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Add @open-turo/semantic-release-jira to the shared semantic-release config.
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: standardize Jira integration across Turo services that use this shared config so release notes can link commits/branches/PRs back to their Jira issues without each repo wiring up the plugin individually.

What changed:
- Adds @open-turo/semantic-release-jira to the base config, between release-notes-generator and github. All presets (default, npm, gradle, gradle-and-npm, openapi) pick it up automatically.
- Configuration is fully driven by SEMANTIC_RELEASE_JIRA_* env vars. The plugin is a noop when no env vars are set, so existing consumers see zero behavior change on upgrade (no major bump).
- Shifts index-based test lookups and the base-config snapshot by +1 to account for the new plugin slot.
- Documents the four configuration tiers (disabled / read-only / authenticated read / write) in the README.

Testing performed:
- npm test: 17/17 pass (unit + integration via semantic-release dry-run with each preset).
- npm run lint: clean.
- pre-commit run -a: clean.

Risk / rollout:
- Low. Plugin is dormant unless consumers opt in via SEMANTIC_RELEASE_JIRA_SERVER_URL. Minor bump.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* feat: add @open-turo/semantic-release-jira plugin (+295/-29)
* docs: document jira integration (+25/-0)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)