### PR TITLE
fix/npm-provenance-sha

### DIFF
--- a/src/_config.ts
+++ b/src/_config.ts
@@ -1,5 +1,6 @@
 import micromatch from "micromatch";
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import * as process from "node:process";
 
 import baseConfig from "~/index.js";
@@ -13,17 +14,28 @@ interface InlineSemanticReleasePlugin {
   verifyConditions: () => void;
 }
 
+interface PullRequestEventPayload {
+  pull_request?: {
+    merge_commit_sha?: string;
+  };
+}
+
 // We have a set of plugins that ideally should run after every other plugin to guarantee that things like publishing to NPM
 // already happen before these plugins run
 const pluginsThatGoAtTheEnd = new Set(["@semantic-release/exec"]);
 
 /**
- * `open-turo/actions-release/semantic-release` overrides GITHUB_REF to the PR's head branch name (instead of
- * the pull_request merge ref) so semantic-release can match the branch against configured release branches.
- * npm trusted publishing (OIDC provenance) also reads GITHUB_REF, but expects it to match what GitHub's OIDC
- * token attests to - the merge ref for pull_request-triggered runs - so the override makes `npm publish`
- * fail provenance verification for PR-triggered prereleases. The action exposes the un-overridden ref via
- * GITHUB_REF_VALUE; restore it before any plugin (e.g. @semantic-release/npm) publishes.
+ * `open-turo/actions-release/semantic-release` overrides GITHUB_REF (to the PR's head branch name) and
+ * GITHUB_SHA (to the PR's head commit) so semantic-release can match the branch against configured release
+ * branches. npm trusted publishing (OIDC provenance) also reads both, but expects them to match what
+ * GitHub's OIDC token attests to for pull_request-triggered runs: the merge ref (`refs/pull/<n>/merge`) and
+ * the SHA of the ephemeral merge commit it currently points to - not the PR's head branch/commit. The
+ * override therefore makes `npm publish` fail provenance verification for PR-triggered prereleases.
+ *
+ * The action exposes the un-overridden ref via GITHUB_REF_VALUE, but not the merge commit SHA, so that part
+ * is recovered from the `pull_request` webhook payload at GITHUB_EVENT_PATH (`pull_request.merge_commit_sha`
+ * is GitHub's own record of what `refs/pull/<n>/merge` currently resolves to). Both are restored before any
+ * plugin (e.g. @semantic-release/npm) publishes.
  *
  * This mutates `process.env` directly rather than the `context.env` passed into the hook: semantic-release
  * deep-clones `context` for every plugin step (see `normalize.js`'s `validator`), so mutating `context.env`
@@ -36,6 +48,19 @@ export const restoreGithubReferenceForNpmProvenance: InlineSemanticReleasePlugin
     verifyConditions() {
       if (process.env.GITHUB_REF_VALUE) {
         process.env.GITHUB_REF = process.env.GITHUB_REF_VALUE;
+      }
+
+      if (
+        process.env.GITHUB_EVENT_NAME === "pull_request" &&
+        process.env.GITHUB_EVENT_PATH
+      ) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const event = JSON.parse(
+          readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"),
+        ) as PullRequestEventPayload;
+        if (event.pull_request?.merge_commit_sha) {
+          process.env.GITHUB_SHA = event.pull_request.merge_commit_sha;
+        }
       }
     },
   };

--- a/test/_config.test.ts
+++ b/test/_config.test.ts
@@ -1,5 +1,6 @@
 import { template } from "lodash";
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
@@ -23,6 +24,10 @@ function isGitPluginConfig(object: unknown): object is GitPluginConfig {
 
 vi.mock("node:child_process", () => ({
   execSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(),
 }));
 
 describe("config", () => {
@@ -55,6 +60,10 @@ describe("config", () => {
     afterEach(() => {
       delete process.env.GITHUB_REF_VALUE;
       delete process.env.GITHUB_REF;
+      delete process.env.GITHUB_EVENT_NAME;
+      delete process.env.GITHUB_EVENT_PATH;
+      delete process.env.GITHUB_SHA;
+      vi.mocked(readFileSync).mockReset();
     });
 
     test("restores process.env.GITHUB_REF from GITHUB_REF_VALUE so npm provenance matches the OIDC-attested ref", () => {
@@ -72,6 +81,38 @@ describe("config", () => {
       config.restoreGithubReferenceForNpmProvenance.verifyConditions();
 
       expect(process.env.GITHUB_REF).toBe("refs/heads/main");
+    });
+
+    test("restores process.env.GITHUB_SHA from the pull_request event's merge_commit_sha so npm provenance matches the OIDC-attested digest", () => {
+      process.env.GITHUB_EVENT_NAME = "pull_request";
+      // eslint-disable-next-line sonarjs/publicly-writable-directories -- readFileSync is mocked, no real I/O
+      process.env.GITHUB_EVENT_PATH = "/tmp/event.json";
+      process.env.GITHUB_SHA = "450b7abf1022e1998c74ee414b594b612ffcc2eb";
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          pull_request: {
+            merge_commit_sha: "d2546efb194b521adc56eb0a544a0b58d019e00d",
+          },
+        }),
+      );
+
+      config.restoreGithubReferenceForNpmProvenance.verifyConditions();
+
+      expect(process.env.GITHUB_SHA).toBe(
+        "d2546efb194b521adc56eb0a544a0b58d019e00d",
+      );
+    });
+
+    test("leaves process.env.GITHUB_SHA untouched when the event is not a pull_request", () => {
+      process.env.GITHUB_EVENT_NAME = "push";
+      process.env.GITHUB_SHA = "450b7abf1022e1998c74ee414b594b612ffcc2eb";
+
+      config.restoreGithubReferenceForNpmProvenance.verifyConditions();
+
+      expect(process.env.GITHUB_SHA).toBe(
+        "450b7abf1022e1998c74ee414b594b612ffcc2eb",
+      );
+      expect(readFileSync).not.toHaveBeenCalled();
     });
   });
 

--- a/test/_config.test.ts
+++ b/test/_config.test.ts
@@ -1,7 +1,7 @@
 import { template } from "lodash";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
   createPluginIfFilesExist,
@@ -57,7 +57,10 @@ describe("config", () => {
   });
 
   describe("restoreGithubReferenceForNpmProvenance", () => {
-    afterEach(() => {
+    // These tests run inside real CI, which sets GITHUB_EVENT_NAME/GITHUB_EVENT_PATH/etc. on the
+    // ambient process.env for its own pull_request-triggered run. Clear them before every test (not
+    // just after) so that ambient state never leaks into a test that doesn't set them itself.
+    beforeEach(() => {
       delete process.env.GITHUB_REF_VALUE;
       delete process.env.GITHUB_REF;
       delete process.env.GITHUB_EVENT_NAME;


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Also restore GITHUB_SHA to the pull_request merge commit for npm provenance
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: PR #325 fixed the GITHUB_REF mismatch, which surfaced a second, previously-hidden provenance mismatch on the commit digest. actions-release/semantic-release overrides GITHUB_SHA to the PR head commit (needed so semantic-release's own logic operates on the right commit), but npm's OIDC provenance expects it to match the SHA GitHub's token attests to for pull_request-triggered runs - the ephemeral refs/pull/<n>/merge commit.

What changed:
- Extend restoreGithubReferenceForNpmProvenance to also restore process.env.GITHUB_SHA, recovered from the pull_request webhook payload (GITHUB_EVENT_PATH -> pull_request.merge_commit_sha), since the action doesn't expose the original SHA the way it exposes GITHUB_REF_VALUE.

Testing: unit tests for both the restore and no-op (non-pull_request) cases. Verified the expected value directly against PR #273: refs/pull/273/merge currently resolves to the exact SHA npm's error reported as the expected SourceRepositoryDigest.

Risk: no-op for regular (push) releases and for any non-pull_request event, since the guard checks GITHUB_EVENT_NAME first.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix: also restore GITHUB_SHA to the pull_request merge commit for npm provenance (+72/-6)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)