### PR TITLE
fix/npm-provenance-sha

### DIFF
--- a/src/_config.ts
+++ b/src/_config.ts
@@ -11,12 +11,17 @@ export type SemanticReleasePlugin =
   | string;
 
 interface InlineSemanticReleasePlugin {
-  verifyConditions: () => void;
+  publish?: () => Promise<void>;
+  verifyConditions?: () => void;
+}
+
+interface PullRequestApiResponse {
+  merge_commit_sha?: string;
 }
 
 interface PullRequestEventPayload {
   pull_request?: {
-    merge_commit_sha?: string;
+    number?: number;
   };
 }
 
@@ -32,10 +37,17 @@ const pluginsThatGoAtTheEnd = new Set(["@semantic-release/exec"]);
  * the SHA of the ephemeral merge commit it currently points to - not the PR's head branch/commit. The
  * override therefore makes `npm publish` fail provenance verification for PR-triggered prereleases.
  *
- * The action exposes the un-overridden ref via GITHUB_REF_VALUE, but not the merge commit SHA, so that part
- * is recovered from the `pull_request` webhook payload at GITHUB_EVENT_PATH (`pull_request.merge_commit_sha`
- * is GitHub's own record of what `refs/pull/<n>/merge` currently resolves to). Both are restored before any
- * plugin (e.g. @semantic-release/npm) publishes.
+ * The action exposes the un-overridden ref via GITHUB_REF_VALUE, so GITHUB_REF is restored eagerly in
+ * verifyConditions - it's just a branch name, there's nothing to go stale.
+ *
+ * GITHUB_SHA is trickier: the action doesn't expose the original value, and GitHub recomputes
+ * `refs/pull/<n>/merge` asynchronously, so any snapshot of it (e.g. the `pull_request.merge_commit_sha`
+ * webhook payload at GITHUB_EVENT_PATH) can go stale between when it's read and when npm actually publishes,
+ * especially right after a force-push. There's no way to eliminate that race entirely from here, only shrink
+ * it: fetch the PR's *current* merge_commit_sha from the GitHub API as a `publish` hook - guaranteed (by
+ * this plugin being first in the array) to run right before @semantic-release/npm's own publish, i.e. as
+ * late as possible, after every other plugin's verifyConditions/analyzeCommits/verifyRelease/generateNotes/
+ * prepare has already run.
  *
  * This mutates `process.env` directly rather than the `context.env` passed into the hook: semantic-release
  * deep-clones `context` for every plugin step (see `normalize.js`'s `validator`), so mutating `context.env`
@@ -45,22 +57,52 @@ const pluginsThatGoAtTheEnd = new Set(["@semantic-release/exec"]);
  */
 export const restoreGithubReferenceForNpmProvenance: InlineSemanticReleasePlugin =
   {
+    async publish() {
+      if (
+        process.env.GITHUB_EVENT_NAME !== "pull_request" ||
+        !process.env.GITHUB_EVENT_PATH ||
+        !process.env.GITHUB_REPOSITORY ||
+        !process.env.GITHUB_TOKEN
+      ) {
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const event = JSON.parse(
+        readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"),
+      ) as PullRequestEventPayload;
+      const prNumber = event.pull_request?.number;
+      if (!prNumber) {
+        return;
+      }
+
+      try {
+        // This plugin only ever runs inside open-turo/actions-release/semantic-release, which pins
+        // Node to 24.16.0 regardless of what a consuming package declares as its own engines.node
+        // floor, so `fetch` is always available here even though it predates this package's floor.
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        const response = await fetch(
+          `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/pulls/${String(prNumber)}`,
+          {
+            headers: {
+              accept: "application/vnd.github+json",
+              authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            },
+          },
+        );
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const pr = (await response.json()) as PullRequestApiResponse;
+        if (pr.merge_commit_sha) {
+          process.env.GITHUB_SHA = pr.merge_commit_sha;
+        }
+      } catch {
+        // Best effort: if the GitHub API is unreachable, leave GITHUB_SHA as-is rather than
+        // failing the whole release over a provenance nicety.
+      }
+    },
     verifyConditions() {
       if (process.env.GITHUB_REF_VALUE) {
         process.env.GITHUB_REF = process.env.GITHUB_REF_VALUE;
-      }
-
-      if (
-        process.env.GITHUB_EVENT_NAME === "pull_request" &&
-        process.env.GITHUB_EVENT_PATH
-      ) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const event = JSON.parse(
-          readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"),
-        ) as PullRequestEventPayload;
-        if (event.pull_request?.merge_commit_sha) {
-          process.env.GITHUB_SHA = event.pull_request.merge_commit_sha;
-        }
       }
     },
   };

--- a/test/__snapshots__/_config.test.ts.snap
+++ b/test/__snapshots__/_config.test.ts.snap
@@ -9,6 +9,7 @@ exports[`config > createPreset > creates a preset including the default config 1
   ],
   "plugins": [
     {
+      "publish": [Function],
       "verifyConditions": [Function],
     },
     "@semantic-release/commit-analyzer",

--- a/test/_config.test.ts
+++ b/test/_config.test.ts
@@ -65,15 +65,18 @@ describe("config", () => {
       delete process.env.GITHUB_REF;
       delete process.env.GITHUB_EVENT_NAME;
       delete process.env.GITHUB_EVENT_PATH;
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GITHUB_TOKEN;
       delete process.env.GITHUB_SHA;
       vi.mocked(readFileSync).mockReset();
+      vi.stubGlobal("fetch", vi.fn());
     });
 
     test("restores process.env.GITHUB_REF from GITHUB_REF_VALUE so npm provenance matches the OIDC-attested ref", () => {
       process.env.GITHUB_REF = "refs/heads/feat/some-branch";
       process.env.GITHUB_REF_VALUE = "refs/pull/273/merge";
 
-      config.restoreGithubReferenceForNpmProvenance.verifyConditions();
+      config.restoreGithubReferenceForNpmProvenance.verifyConditions?.();
 
       expect(process.env.GITHUB_REF).toBe("refs/pull/273/merge");
     });
@@ -81,41 +84,79 @@ describe("config", () => {
     test("leaves process.env.GITHUB_REF untouched when GITHUB_REF_VALUE is not set", () => {
       process.env.GITHUB_REF = "refs/heads/main";
 
-      config.restoreGithubReferenceForNpmProvenance.verifyConditions();
+      config.restoreGithubReferenceForNpmProvenance.verifyConditions?.();
 
       expect(process.env.GITHUB_REF).toBe("refs/heads/main");
     });
 
-    test("restores process.env.GITHUB_SHA from the pull_request event's merge_commit_sha so npm provenance matches the OIDC-attested digest", () => {
+    test("restores process.env.GITHUB_SHA from the PR's live merge_commit_sha so npm provenance matches the OIDC-attested digest", async () => {
       process.env.GITHUB_EVENT_NAME = "pull_request";
       // eslint-disable-next-line sonarjs/publicly-writable-directories -- readFileSync is mocked, no real I/O
       process.env.GITHUB_EVENT_PATH = "/tmp/event.json";
+      process.env.GITHUB_REPOSITORY = "open-turo/semantic-release-config";
+      process.env.GITHUB_TOKEN = "test-token";
       process.env.GITHUB_SHA = "450b7abf1022e1998c74ee414b594b612ffcc2eb";
       vi.mocked(readFileSync).mockReturnValue(
-        JSON.stringify({
-          pull_request: {
-            merge_commit_sha: "d2546efb194b521adc56eb0a544a0b58d019e00d",
-          },
+        JSON.stringify({ pull_request: { number: 273 } }),
+      );
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins, @typescript-eslint/consistent-type-assertions -- fetch is always available here (see src/_config.ts); Response is large, only json() matters for this mock
+      vi.mocked(fetch).mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            merge_commit_sha: "8eba7d0bfce68135b79e23a20cd68759d66ecfdf",
+          }),
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      } as Response);
+
+      await config.restoreGithubReferenceForNpmProvenance.publish?.();
+
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      expect(fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/open-turo/semantic-release-config/pulls/273",
+        expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- vitest's expect.objectContaining() typing is any
+          headers: expect.objectContaining({
+            authorization: "Bearer test-token",
+          }),
         }),
       );
-
-      config.restoreGithubReferenceForNpmProvenance.verifyConditions();
-
       expect(process.env.GITHUB_SHA).toBe(
-        "d2546efb194b521adc56eb0a544a0b58d019e00d",
+        "8eba7d0bfce68135b79e23a20cd68759d66ecfdf",
       );
     });
 
-    test("leaves process.env.GITHUB_SHA untouched when the event is not a pull_request", () => {
+    test("leaves process.env.GITHUB_SHA untouched when the event is not a pull_request", async () => {
       process.env.GITHUB_EVENT_NAME = "push";
       process.env.GITHUB_SHA = "450b7abf1022e1998c74ee414b594b612ffcc2eb";
 
-      config.restoreGithubReferenceForNpmProvenance.verifyConditions();
+      await config.restoreGithubReferenceForNpmProvenance.publish?.();
 
       expect(process.env.GITHUB_SHA).toBe(
         "450b7abf1022e1998c74ee414b594b612ffcc2eb",
       );
       expect(readFileSync).not.toHaveBeenCalled();
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test("leaves process.env.GITHUB_SHA untouched when the GitHub API call fails", async () => {
+      process.env.GITHUB_EVENT_NAME = "pull_request";
+      // eslint-disable-next-line sonarjs/publicly-writable-directories -- readFileSync is mocked, no real I/O
+      process.env.GITHUB_EVENT_PATH = "/tmp/event.json";
+      process.env.GITHUB_REPOSITORY = "open-turo/semantic-release-config";
+      process.env.GITHUB_TOKEN = "test-token";
+      process.env.GITHUB_SHA = "450b7abf1022e1998c74ee414b594b612ffcc2eb";
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ pull_request: { number: 273 } }),
+      );
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      vi.mocked(fetch).mockRejectedValue(new Error("network error"));
+
+      await config.restoreGithubReferenceForNpmProvenance.publish?.();
+
+      expect(process.env.GITHUB_SHA).toBe(
+        "450b7abf1022e1998c74ee414b594b612ffcc2eb",
+      );
     });
   });
 


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Fetch merge_commit_sha from the live GitHub API instead of the webhook payload
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
Why: #326 fixed GITHUB_SHA using the pull_request webhook payload's merge_commit_sha, but that's a snapshot frozen at event-dispatch time. GitHub recomputes refs/pull/<n>/merge asynchronously, so the snapshot can go stale by the time npm actually publishes, especially right after a force-push - confirmed live against PR #273, where the previously-correct value had gone stale by publish time.

What changed:
- Move the GITHUB_SHA restore into a publish hook instead of verifyConditions, still guaranteed to run before @semantic-release/npm's own publish (this plugin is first in the plugins array), but as late as structurally possible in the lifecycle - shrinking the race window since it can't be eliminated entirely from this side.
- Fetch the PR's current merge_commit_sha from the GitHub API at that point rather than trusting the payload snapshot.
- Fail soft: leave GITHUB_SHA untouched if the API call errors, rather than failing the whole release over a provenance nicety.

Testing: unit tests for the restore, the non-pull_request no-op, and the API-failure fallback. Verified the exact request (URL, headers, auth) against the live GitHub API for PR #273 and got back the exact value currently expected.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix: query the GitHub API live instead of trusting the webhook payload's merge_commit_sha (+114/-30)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)