### PR TITLE
b/fix-release-notes-generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@semantic-release/github": "^12.0.0",
         "@semantic-release/npm": "^13.0.0",
         "@semantic-release/release-notes-generator": "^14.0.1",
-        "conventional-changelog-conventionalcommits": "^10.0.0",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "gradle-semantic-release-plugin": "^1.10.3",
         "micromatch": "^4.0.5"
       },
@@ -3705,15 +3705,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.0.0.tgz",
-      "integrity": "sha512-gJCWgneQIGfxZ22B4nGh7LF3cHbIdhwTHZi9octL7kagH4UHfnsLvp/yPl6tzWvdnIIRUutJtVNEih6Ln2YzFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -6863,15 +6854,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.0.0.tgz",
-      "integrity": "sha512-MI9NHlb+21eTLJyd6c8mgH2XHGz+ZaQanCFyH1A6AGtqqbTw+w9Ren4Oi5yWFi/pDehlmbnFU1pJzRqQXTOp+w==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.0.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@semantic-release/github": "^12.0.0",
     "@semantic-release/npm": "^13.0.0",
     "@semantic-release/release-notes-generator": "^14.0.1",
-    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "gradle-semantic-release-plugin": "^1.10.3",
     "micromatch": "^4.0.5"
   },

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -314,4 +314,28 @@ paths: {}`,
     },
     30_000,
   );
+
+  // Regression test for https://github.com/semantic-release/release-notes-generator/issues/992:
+  // conventional-changelog-conventionalcommits@10 renders release-notes-generator's changelog
+  // template as only the version header, silently dropping every commit section.
+  test("generates commit sections grouped by type for a mixed feat/fix release", async () => {
+    const repoDirectory = createTestRepo();
+    addCommit(repoDirectory, "feat: add widget export");
+    addCommit(repoDirectory, "fix: correct widget export encoding");
+
+    const config = await loadConfig("");
+    const { result } = await runSemanticRelease(repoDirectory, config);
+
+    expect(result).toBeTruthy();
+    if (!result) {
+      throw new Error("Expected result to be truthy");
+    }
+
+    expect(result.nextRelease.notes).toContain("### Features");
+    expect(result.nextRelease.notes).toContain("add widget export");
+    expect(result.nextRelease.notes).toContain("### Bug Fixes");
+    expect(result.nextRelease.notes).toContain(
+      "correct widget export encoding",
+    );
+  }, 30_000);
 });

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -309,7 +309,8 @@ paths: {}`,
       expect(result.commits).toHaveLength(1);
       expect(result.commits.at(0)?.message).toContain(message);
       expect(result.nextRelease.notes).toBeDefined();
-      expect(result.nextRelease.notes?.length).toBeGreaterThan(0);
+      expect(result.nextRelease.notes).toContain("### Bug Fixes");
+      expect(result.nextRelease.notes).toContain("add open api spec");
     },
     30_000,
   );


### PR DESCRIPTION
**Summary**

<!-- fotingo:start summary -->
Fix release notes generator producing empty changelogs
<!-- fotingo:end summary -->

**Description**

<!-- fotingo:start description -->
**Problem:** Every release since the `conventional-changelog-conventionalcommits` v10 bump (Renovate PR, June 27) silently dropped every commit section from the generated release notes, keeping only the version header. Confirmed against the upstream report: semantic-release/release-notes-generator#992.

**Root cause:** v10 rewrote the conventionalcommits preset to return function-based `template`/`headerPartial`/`commitPartial`/`footerPartial` renderers, but `@semantic-release/release-notes-generator@14` still ships `conventional-changelog-writer@8`, which is Handlebars-based and expects string templates keyed as `mainTemplate` (not `template`), and calls partial functions with Handlebars' own `(context, options)` signature rather than the `(context, commit)` signature v10's `commitPartial` expects. Net effect: a header always renders, but the commit list silently disappears.

**Fix:** Pin `conventional-changelog-conventionalcommits` back to `9.3.1`, matching the fix recommended by the release-notes-generator maintainers until the ecosystem catches up with v10's new renderer API.

**Testing:**
- Reproduced the bug locally by rendering notes directly through the release-notes-generator/conventional-changelog-writer pipeline with v10 (0.0.0 through 10.2.1, the latest) vs 9.3.1 - only 9.3.1 produces commit sections.
- Strengthened the existing per-preset integration test to assert on rendered commit content instead of just non-empty notes (the old assertion passed even with the bug, since the header alone is non-empty).
- Added a dedicated regression test exercising a mixed feat/fix release, verified it fails against v10.0.0-10.2.1 and passes against the pinned 9.3.1.
- Full test suite (23 tests) and pre-commit pass.
<!-- fotingo:end description -->

<!-- fotingo:start fixed-issues -->
<!-- fotingo:end fixed-issues -->

<!-- fotingo:start stacked-prs -->
<!-- fotingo:end stacked-prs -->

**Changes**

<!-- fotingo:start changes -->
* fix(deps): pin conventional-changelog-conventionalcommits back to 9.3.1 (+9/-17)
* test: add dedicated regression test for release-notes-generator commit sections (+24/-0)
<!-- fotingo:end changes -->

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)